### PR TITLE
Update try-it guide to refer v1alpha4 instead of v1alpha3

### DIFF
--- a/try-it.md
+++ b/try-it.md
@@ -22,6 +22,7 @@ permalink: /try-it.html
 
 <!-- /TOC -->
 <hr>
+
 ## 1. Environment-Setup
 
 > info "Naming"
@@ -227,9 +228,9 @@ status:
 
 This section describes how to trigger provisioning of a cluster and hosts via
 `Machine` objects as part of the Cluster API integration. This uses Cluster API
-[v1alpha3](https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.0) and
+[v1alpha4](https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.0) and
 assumes that metal3-dev-env is deployed with the environment variable
-**CAPM3_VERSION** set to **v1alpha3**. The v1alpha3 deployment can be done with
+**CAPM3_VERSION** set to **v1alpha4**. This is the default behaviour. The v1alpha4 deployment can be done with
 Ubuntu 18.04 or Centos 8 target host images. Please make sure to meet [resource requirements](#11-prerequisites) for successfull deployment:
 
 The following scripts can be used to provision a cluster, controlplane node and worker node.

--- a/try-it.md
+++ b/try-it.md
@@ -113,7 +113,7 @@ represented by `BareMetalHost` objects in our management cluster. The yaml
 defition file used to create these host objects is in `bmhosts_crs.yaml`.
 
 ```sh
-$ kubectl get baremetalhosts -n metal3
+$ kubectl get baremetalhosts -n metal3 -o wide
 NAME     STATUS   PROVISIONING STATUS   CONSUMER   BMC                         HARDWARE PROFILE   ONLINE   ERROR
 node-0   OK       ready                            ipmi://192.168.111.1:6230   unknown            true
 node-1   OK       ready                            ipmi://192.168.111.1:6231   unknown            true
@@ -378,7 +378,7 @@ The `BareMetalHost` will go through the provisioning process, and will
 eventually reboot into the operating system we wrote to disk.
 
 ```sh
-$ kubectl get baremetalhost node-0 -n metal3
+$ kubectl get baremetalhost node-0 -n metal3 -o wide
 NAME       STATUS   PROVISIONING STATUS   MACHINE   BMC                         HARDWARE PROFILE   ONLINE   ERROR
 node-0     OK       provisioned                     ipmi://192.168.111.1:6230   unknown            true
 ```
@@ -410,7 +410,7 @@ $ ./deprovision_host.sh node-0
 You will then see the host go into a `deprovisioning` status:
 
 ```sh
-$ kubectl get baremetalhost node-0 -n metal3
+$ kubectl get baremetalhost node-0 -n metal3 -o wide
 NAME       STATUS   PROVISIONING STATUS   MACHINE   BMC                         HARDWARE PROFILE   ONLINE   ERROR
 node-0     OK       deprovisioning                  ipmi://192.168.111.1:6230   unknown            true
 ```

--- a/try-it.md
+++ b/try-it.md
@@ -7,17 +7,17 @@ permalink: /try-it.html
 <!-- TOC depthFrom:2 insertAnchor:false orderedList:false updateOnSave:true withLinks:true -->
 
 - [1. Environment Setup](#1-environment-setup)
-   - [1.1. Prerequisites](#11-prerequisites)
-   - [1.2. Setup](#12-setup)
-   - [1.3. Using Custom Image](#13-using-custom-image)
+  - [1.1. Prerequisites](#11-prerequisites)
+  - [1.2. Setup](#12-setup)
+  - [1.3. Using Custom Image](#13-using-custom-image)
 - [2. Working with Environment](#2-working-with-environment)
-   - [2.1. BareMetalHosts](#21-baremetalhosts)
-   - [2.2. Provision Cluster and Machines](#22-provision-cluster-and-machines)
-   - [2.3. Deprovision Cluster and Machines](#23-deprovision-cluster-and-machines)
-   - [2.4. Directly Provision BareMetalHost](#24-directly-provision-baremetalhost)
-   - [2.5. Running Custom Baremetal-Operator](#25-running-custom-baremetal-operator)
-   - [2.6. Running Custom Cluster API Provider Metal3](#26-running-custom-cluster-api-provider-metal3)
-   - [2.7. Accessing Ironic API](#29-accessing-ironic-api)
+  - [2.1. BareMetalHosts](#21-baremetalhosts)
+  - [2.2. Provision Cluster and Machines](#22-provision-cluster-and-machines)
+  - [2.3. Deprovision Cluster and Machines](#23-deprovision-cluster-and-machines)
+  - [2.4. Directly Provision BareMetalHost](#24-directly-provision-baremetalhost)
+  - [2.5. Running Custom Baremetal-Operator](#25-running-custom-baremetal-operator)
+  - [2.6. Running Custom Cluster API Provider Metal3](#26-running-custom-cluster-api-provider-metal3)
+  - [2.7. Accessing Ironic API](#29-accessing-ironic-api)
 
 <!-- /TOC -->
 <hr>
@@ -26,7 +26,7 @@ permalink: /try-it.html
 
 > info "Naming"
 > For the v1alpha3 release, the Cluster API provider for Metal3 was renamed from
-> Cluster API provider BareMetal (CAPBM) to Cluster API provider Metal3 (CAPM3). Hence, 
+> Cluster API provider BareMetal (CAPBM) to Cluster API provider Metal3 (CAPM3). Hence,
 > from v1alpha3 onwards it is Cluster API provider Metal3.
 
 ### 1.1. Prerequisites
@@ -41,9 +41,9 @@ permalink: /try-it.html
 > info "Information"
 > If you need detailed information regarding the process of creating a Metal³ emulated environment using metal3-dev-env, it is worth taking a look at the blog post ["A detailed walkthrough of the Metal³ development environment"]({% post_url 2020-02-18-metal3-dev-env-install-deep-dive %}).
 
-This is a high-level architecture of the Metal³-dev-env. Note that for Ubuntu based setup, either Kind or Minikube can be used to instantiate an ephemeral cluster, while for CentOS based setup only Minikube is currently supported. Ephemeral cluster creation tool can be manipulated with EPHEMERAL_CLUSTER environment variable. 
+This is a high-level architecture of the Metal³-dev-env. Note that for Ubuntu based setup, either Kind or Minikube can be used to instantiate an ephemeral cluster, while for CentOS based setup only Minikube is currently supported. Ephemeral cluster creation tool can be manipulated with EPHEMERAL_CLUSTER environment variable.
 
-<p align="center">
+<p style="text-align: center">
   <img src="assets/images/metal3-dev-env.svg">
 </p>
 
@@ -62,7 +62,7 @@ The `Makefile` runs a series of scripts, described here:
   were bare metal hosts. It also downloads some images needed for Ironic.
 
 - `03_launch_mgmt_cluster.sh` - Launches a management cluster using `minikube` or `kind`
-and runs the `baremetal-operator` on that cluster.
+  and runs the `baremetal-operator` on that cluster.
 
 - `04_verify.sh` - Runs a set of tests that verify that the deployment completed successfully.
 
@@ -73,9 +73,10 @@ To tear down the environment, run
 ```sh
 $ make clean
 ```
+
 > info "Note"
 > When redeploying metal³-dev-env with a different release version of CAPM3, you
-> must set the `FORCE_REPO_UPDATE` variable in `config_${user}.sh` to *true*.
+> must set the `FORCE_REPO_UPDATE` variable in `config_${user}.sh` to _true_.
 
 ### 1.3. Using Custom Image
 
@@ -86,10 +87,12 @@ downloaded from the `IMAGE_LOCATION` value configured.
 
 > warning "Warning"
 > If you see this error during the installation:
->```
+>
+> ```
 > error: failed to connect to the hypervisor \
 > error: Failed to connect socket to '/var/run/libvirt/libvirt-sock':  Permission denied
->```
+> ```
+>
 > You may need to log out then login again, and run `make clean` and `make` again.
 
 ## 2. Working with Environment
@@ -257,7 +260,7 @@ $ kubectl logs -n capm3 pod/capm3-manager-7bbc6897c7-bp2pw -c manager
 
 ```
 
-If you look at the yaml representation of the `Machine` object, you will see a 
+If you look at the yaml representation of the `Machine` object, you will see a
 new annotation that identifies which `BareMetalHost` was chosen to satisfy this
 `Machine` request.
 
@@ -283,8 +286,8 @@ node-1   OK       provisioning          test1-controlplane-0   ipmi://192.168.11
 
 You should be able to ssh into your host once provisioning is completed.
 The default username for both CentOS & Ubuntu image is `metal3`.
-For the IP address, you can either use API endpoint IP of the target cluster 
-which is - `192.168.111.249` by default or use predictable IP address of the first 
+For the IP address, you can either use API endpoint IP of the target cluster
+which is - `192.168.111.249` by default or use predictable IP address of the first
 master node - `192.168.111.100`.
 
 ```sh
@@ -312,7 +315,6 @@ $ kubectl scale machinedeployment test1-md-0 --replicas=0
 
 Below, it is shown how the deprovisioning can be executed in a more manual way by just deleting the proper Custom Resources (CR)
 
-
 ```sh
 $ kubectl delete machine test1-md-0-m87bq -n metal3
 machine.cluster.x-k8s.io "test1-md-0-m87bq" deleted
@@ -337,6 +339,7 @@ $ kubectl get cluster -n metal3
 NAME    PHASE
 test1   deprovisioning
 ```
+
 ### 2.4. Directly Provision BareMetalHost
 
 It’s also possible to provision via the `BareMetalHost` interface directly
@@ -437,17 +440,16 @@ Sometimes you may want to look directly at Ironic to debug something.
 The metal3-dev-env repository contains a clouds.yaml file with
 connection settings for Ironic.
 
-Metal3-dev-env will install the unified OpenStack and standalone 
-OpenStack Ironic command-line clients on the provisioning host as 
-part of setting up the cluster. 
+Metal3-dev-env will install the unified OpenStack and standalone
+OpenStack Ironic command-line clients on the provisioning host as
+part of setting up the cluster.
 
 Note that currently you can use either unified OpenStack client
 or Ironic client. In this example we are using Ironic client to interact
 with Ironic API.
 
-Please make sure to export
-```CONTAINER_RUNTIME``` environment variable before you execute
-commands.
+Please make sure to export `CONTAINER_RUNTIME` environment variable before
+you execute commands.
 
 Example:
 

--- a/try-it.md
+++ b/try-it.md
@@ -10,6 +10,7 @@ permalink: /try-it.html
   - [1.1. Prerequisites](#11-prerequisites)
   - [1.2. Setup](#12-setup)
   - [1.3. Using Custom Image](#13-using-custom-image)
+  - [1.4. Setting environment variables](#14-setting-environment-variables)
 - [2. Working with Environment](#2-working-with-environment)
   - [2.1. BareMetalHosts](#21-baremetalhosts)
   - [2.2. Provision Cluster and Machines](#22-provision-cluster-and-machines)
@@ -78,13 +79,6 @@ $ make clean
 > When redeploying metal³-dev-env with a different release version of CAPM3, you
 > must set the `FORCE_REPO_UPDATE` variable in `config_${user}.sh` to _true_.
 
-### 1.3. Using Custom Image
-
-Whether you want to run target cluster Nodes with your own image, you can override the three following variables: `IMAGE_NAME`,
-`IMAGE_LOCATION`, `IMAGE_USERNAME`. If the requested image with name `IMAGE_NAME` does not
-exist in the `IRONIC_IMAGE_DIR` (/opt/metal3-dev-env/ironic/html/images) folder, then it will be automatically
-downloaded from the `IMAGE_LOCATION` value configured.
-
 > warning "Warning"
 > If you see this error during the installation:
 >
@@ -94,6 +88,22 @@ downloaded from the `IMAGE_LOCATION` value configured.
 > ```
 >
 > You may need to log out then login again, and run `make clean` and `make` again.
+
+### 1.3. Using Custom Image
+
+Whether you want to run target cluster Nodes with your own image, you can override the three following variables: `IMAGE_NAME`,
+`IMAGE_LOCATION`, `IMAGE_USERNAME`. If the requested image with name `IMAGE_NAME` does not
+exist in the `IRONIC_IMAGE_DIR` (/opt/metal3-dev-env/ironic/html/images) folder, then it will be automatically
+downloaded from the `IMAGE_LOCATION` value configured.
+
+### 1.4. Setting environment variables
+
+To set environment variables persistently, export them from the configuration file used by metal³-dev-env scripts:
+
+```bash
+$ cp config_example.sh config_$(whoami).sh
+$ vim config_$(whoami).sh
+```
 
 ## 2. Working with Environment
 
@@ -113,7 +123,7 @@ $ sudo virsh list
 
 Each of the VMs (aside from the `minikube` management cluster VM) are
 represented by `BareMetalHost` objects in our management cluster. The yaml
-defition file used to create these host objects is in `bmhosts_crs.yaml`.
+definition file used to create these host objects is in `bmhosts_crs.yaml`.
 
 ```sh
 $ kubectl get baremetalhosts -n metal3 -o wide
@@ -233,7 +243,7 @@ This section describes how to trigger provisioning of a cluster and hosts via
 [v1alpha4](https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.0) and
 assumes that metal3-dev-env is deployed with the environment variable
 **CAPM3_VERSION** set to **v1alpha4**. This is the default behaviour. The v1alpha4 deployment can be done with
-Ubuntu 18.04 or Centos 8 target host images. Please make sure to meet [resource requirements](#11-prerequisites) for successfull deployment:
+Ubuntu 18.04 or Centos 8 target host images. Please make sure to meet [resource requirements](#11-prerequisites) for successful deployment:
 
 The following scripts can be used to provision a cluster, controlplane node and worker node.
 

--- a/try-it.md
+++ b/try-it.md
@@ -7,23 +7,22 @@ permalink: /try-it.html
 <!-- TOC depthFrom:2 insertAnchor:false orderedList:false updateOnSave:true withLinks:true -->
 
 - [1. Environment Setup](#1-environment-setup)
-    - [1.1. Prerequisites](#11-prerequisites)
-    - [1.2. Setup](#12-setup)
-    - [1.3. Using Custom Image](#13-using-custom-image)
+   - [1.1. Prerequisites](#11-prerequisites)
+   - [1.2. Setup](#12-setup)
+   - [1.3. Using Custom Image](#13-using-custom-image)
 - [2. Working with Environment](#2-working-with-environment)
-    - [2.1. BareMetalHosts](#21-baremetalhosts)
-    - [2.2. Provision Cluster and Machines](#22-provision-cluster-and-machines)
-    - [2.3. Deprovision Cluster and Machines](#23-deprovision-cluster-and-machines)
-    - [2.4. Image configuration (Centos 7 target hosts only)](#24-image-configuration-centos-7-target-hosts-only)
-    - [2.5. Directly Provision BareMetalHost](#25-directly-provision-baremetalhost)
-    - [2.6. Running Custom Baremetal-Operator](#26-running-custom-baremetal-operator)
-    - [2.7. Running Custom Cluster API Provider Metal3](#27-running-custom-cluster-api-provider-metal3)
-    - [2.8. Accessing Ironic API](#28-accessing-ironic-api)
+   - [2.1. BareMetalHosts](#21-baremetalhosts)
+   - [2.2. Provision Cluster and Machines](#22-provision-cluster-and-machines)
+   - [2.3. Deprovision Cluster and Machines](#23-deprovision-cluster-and-machines)
+   - [2.4. Directly Provision BareMetalHost](#24-directly-provision-baremetalhost)
+   - [2.5. Running Custom Baremetal-Operator](#25-running-custom-baremetal-operator)
+   - [2.6. Running Custom Cluster API Provider Metal3](#26-running-custom-cluster-api-provider-metal3)
+   - [2.7. Accessing Ironic API](#29-accessing-ironic-api)
 
 <!-- /TOC -->
 <hr>
 
-## 1. Environment-Setup
+## 1. Environment Setup
 
 > info "Naming"
 > For the v1alpha3 release, the Cluster API provider for Metal3 was renamed from
@@ -338,32 +337,7 @@ $ kubectl get cluster -n metal3
 NAME    PHASE
 test1   deprovisioning
 ```
-
-### 2.4. Image Configuration (Centos 7 target hosts only)
-
-If you want to deploy Ubuntu hosts, please skip this section.
-
-As shown in the [prerequisites](#11-prerequisites) section, the preferred OS image for CentOS is version 8. Actually, for both the system where the metal3-dev-env environment is configured and the target cluster nodes.
-
-Wheter you still want to deploy Centos 7 for the target hosts, the following variables needs to be modified:
-
-```
-IMAGE_NAME_CENTOS="centos-updated.qcow2"
-IMAGE_LOCATION_CENTOS="http://artifactory.nordix.org/artifactory/airship/images/centos.qcow2"
-IMAGE_OS=Centos
-```
-
-Additionally, you can let the Ansible `provision_controlplane.sh` and `provision_worker.sh` download the image automatically following the variables listed above or download the properly configured CentOS 7 image from the following location into the `IRONIC_IMAGE_DIR`:
-
-```sh
-curl -LO http://artifactory.nordix.org/artifactory/airship/images/centos.qcow2
-mv centos.qcow2 /opt/metal3-dev-env/ironic/html/images/centos-updated.qcow2
-md5sum /opt/metal3-dev-env/ironic/html/images/centos-updated.qcow2 | \
-awk '{print $1}' > \
-/opt/metal3-dev-env/ironic/html/images/centos-updated.qcow2.md5sum
-```
-
-### 2.5. Directly Provision BareMetalHost
+### 2.4. Directly Provision BareMetalHost
 
 It’s also possible to provision via the `BareMetalHost` interface directly
 without using the Cluster API integration.
@@ -416,7 +390,7 @@ NAME       STATUS   PROVISIONING STATUS   MACHINE   BMC                         
 node-0     OK       deprovisioning                  ipmi://192.168.111.1:6230   unknown            true
 ```
 
-### 2.6. Running Custom Baremetal-Operator
+### 2.5. Running Custom Baremetal-Operator
 
 The `baremetal-operator` comes up running in the cluster by default, using an
 image built from the [metal3-io/baremetal-operator](https://github.com/metal3-io/baremetal-operator) repository. If you’d like to test changes to the
@@ -438,7 +412,7 @@ cd ~/go/src/github.com/metal3-io/baremetal-operator
 make run
 ```
 
-### 2.7. Running Custom Cluster API Provider Metal3
+### 2.6. Running Custom Cluster API Provider Metal3
 
 There are two Cluster API related managers running in the cluster. One
 includes set of generic controllers, and the other includes a custom Machine
@@ -457,7 +431,7 @@ cd ~/go/src/github.com/metal3-io/cluster-api-provider-metal3
 make run
 ```
 
-### 2.8. Accessing Ironic API
+### 2.7. Accessing Ironic API
 
 Sometimes you may want to look directly at Ironic to debug something.
 The metal3-dev-env repository contains a clouds.yaml file with


### PR DESCRIPTION
Changed mentions of v1alpha3 to v1alpha4 after verifying the scripts still work. Also fixed minor typos and added a short section about using the `config_user.sh` file